### PR TITLE
Update docs of localsearch

### DIFF
--- a/source/docs/third-party-services/search-services.md
+++ b/source/docs/third-party-services/search-services.md
@@ -159,6 +159,11 @@ local_search:
   unescape: false
   # Preload the search data when the page loads.
   preload: false
+  # Use CDN to accelerate the speed of loading search.xml or search.json
+  cdn:
+    enable: false
+    # url: //cdn.jsdelivr.net/gh/<username>/<username>.github.io/search.xml
+    url: 
 ```
 <!-- endtab -->
 {% endtabs %}


### PR DESCRIPTION
Update docs of localsearch
Perf: Use CDN to accelerate the speed of loading search.xml or search.json