### PR TITLE
add new archive for v8.13.0

### DIFF
--- a/source/_posts/nexT-8-13.0-released.md
+++ b/source/_posts/nexT-8-13.0-released.md
@@ -1,0 +1,28 @@
+---
+title: NexT 8.13.0 Released
+date: 2022-09-13 13:40:57
+---
+
+### 🌟 New Features
+
+- Add matomo as an analytics provider by [@foliet](https://github.com/foliet) in [#553](https://github.com/next-theme/hexo-theme-next/pull/553)
+
+### ⭐ Features
+
+- Upgrade to disqusjs@3 by [@stevenjoezhang](https://github.com/stevenjoezhang) in [#529](https://github.com/next-theme/hexo-theme-next/pull/529)
+
+### 🐞 Bug Fixes
+
+- Fix server_url for lean-analytics by [@stevenjoezhang](https://github.com/stevenjoezhang) in [#555](https://github.com/next-theme/hexo-theme-next/pull/555)
+
+### 🌀 External Changes
+
+- Update dependency eslint to v8.23.0 by [@renovate](https://github.com/renovate) in [#552](https://github.com/next-theme/hexo-theme-next/pull/552)
+- Replace nyc with c8 ([`aacc483`](https://github.com/next-theme/hexo-theme-next/commit/aacc483fc2b4baaa2f01e8361e6f6833de454904))
+
+***
+
+For full changes, see the [comparison between v8.12.3 and v8.13.0](https://github.com/next-theme/hexo-theme-next/compare/v8.12.3...v8.13.0)
+
+[Detailed changes for NexT v8.13.0](https://github.com/next-theme/hexo-theme-next/releases/tag/v8.13.0)
+


### PR DESCRIPTION
[v8.13.0](https://github.com/next-theme/hexo-theme-next/releases/tag/v8.13.0) has released before 3 days ago, but doc repo don't have release note, so I want to add it.