### PR TITLE
Add tag plugin documentation for Wavedrom.

### DIFF
--- a/_config.next.yml
+++ b/_config.next.yml
@@ -70,6 +70,7 @@ menu:
       Label: /label.html || fa fa-hat-wizard
       Link Grid: /link-grid.html || fa fa-grip-vertical
       Mermaid: /mermaid.html || fa fa-project-diagram
+      WaveDrom: /wavedrom.html || fa fa-diagram-predecessor
       Note: /note.html || fa fa-adjust
       PDF: /pdf.html || fa fa-file-pdf
       Tabs: /tabs.html || fa fa-columns
@@ -220,6 +221,9 @@ tabs:
     labels: true
 
 mermaid:
+  enable: true
+
+wavedrom:
   enable: true
 
 

--- a/source/docs/tag-plugins/index.md
+++ b/source/docs/tag-plugins/index.md
@@ -12,7 +12,7 @@ Tag Plugin is a way to make special style contents supported by Hexo. For exampl
 * [Label](/docs/tag-plugins/label.html)
 * [Link Grid](/docs/tag-plugins/link-grid.html)
 * [Mermaid](/docs/tag-plugins/mermaid.html)
-* [Wavedrom](/doc/tag-plugins/wavedrom.html)
+* [WaveDrom](/doc/tag-plugins/wavedrom.html)
 * [Note](/docs/tag-plugins/note.html)
 * [PDF](/docs/tag-plugins/pdf.html)
 * [Tabs](/docs/tag-plugins/tabs.html)

--- a/source/docs/tag-plugins/index.md
+++ b/source/docs/tag-plugins/index.md
@@ -12,6 +12,7 @@ Tag Plugin is a way to make special style contents supported by Hexo. For exampl
 * [Label](/docs/tag-plugins/label.html)
 * [Link Grid](/docs/tag-plugins/link-grid.html)
 * [Mermaid](/docs/tag-plugins/mermaid.html)
+* [Wavedrom](/doc/tag-plugins/wavedrom.html)
 * [Note](/docs/tag-plugins/note.html)
 * [PDF](/docs/tag-plugins/pdf.html)
 * [Tabs](/docs/tag-plugins/tabs.html)

--- a/source/docs/tag-plugins/mermaid.md
+++ b/source/docs/tag-plugins/mermaid.md
@@ -50,6 +50,18 @@ C -->|Two| E[Result 2]
 {% endmermaid %}
 ```
 
+or
+
+~~~markdown
+```mermaid
+graph TD
+A[Hard] -->|Text| B(Round)
+B --> C{Decision}
+C -->|One| D[Result 1]
+C -->|Two| E[Result 2]
+```
+~~~
+
 {% mermaid graph TD %}
 A[Hard] -->|Text| B(Round)
 B --> C{Decision}
@@ -175,28 +187,4 @@ Crash --> [*]
 "Dogs" : 386
 "Cats" : 85
 "Rats" : 15
-{% endmermaid %}
-
-```jinja
-{% mermaid journey %}
-title My working day
-section Go to work
-  Make tea: 5: Me
-  Go upstairs: 3: Me
-  Do work: 1: Me, Cat
-section Go home
-  Go downstairs: 5: Me
-  Sit down: 3: Me
-{% endmermaid %}
-```
-
-{% mermaid journey %}
-title My working day
-section Go to work
-  Make tea: 5: Me
-  Go upstairs: 3: Me
-  Do work: 1: Me, Cat
-section Go home
-  Go downstairs: 5: Me
-  Sit down: 3: Me
 {% endmermaid %}

--- a/source/docs/tag-plugins/wavedrom.md
+++ b/source/docs/tag-plugins/wavedrom.md
@@ -37,3 +37,75 @@ wavedrom:
   { name: "wire", wave: "0.1..0." },
 ]}
 {% endwavedrom %}
+
+```jinja
+{% wavedrom %}
+{ signal: [
+  { name: 'A', wave: '01........0....',  node: '.a........j' },
+  { name: 'B', wave: '0.1.......0.1..',  node: '..b.......i' },
+  { name: 'C', wave: '0..1....0...1..',  node: '...c....h..' },
+  { name: 'D', wave: '0...1..0.....1.',  node: '....d..g...' },
+  { name: 'E', wave: '0....10.......1',  node: '.....ef....' }
+  ],
+  edge: [
+    'a~b t1', 'c-~a t2', 'c-~>d time 3', 'd~-e',
+    'e~>f', 'f->g', 'g-~>h', 'h~>i some text', 'h~->j'
+  ],
+  config:{skin:'lowkey'}
+}
+{% endwavedrom %}
+```
+
+{% wavedrom %}
+{ signal: [
+  { name: 'A', wave: '01........0....',  node: '.a........j' },
+  { name: 'B', wave: '0.1.......0.1..',  node: '..b.......i' },
+  { name: 'C', wave: '0..1....0...1..',  node: '...c....h..' },
+  { name: 'D', wave: '0...1..0.....1.',  node: '....d..g...' },
+  { name: 'E', wave: '0....10.......1',  node: '.....ef....' }
+  ],
+  edge: [
+    'a~b t1', 'c-~a t2', 'c-~>d time 3', 'd~-e',
+    'e~>f', 'f->g', 'g-~>h', 'h~>i some text', 'h~->j'
+  ],
+  config:{skin:'lowkey'}
+}
+{% endwavedrom %}
+
+```jinja
+{% wavedrom %}
+{reg:[
+    {bits: 7,  name: 0x07, attr: [
+      'VLxU,VLE zero-extended',
+      'VLxU,VLE zero-extended, fault-only-first',
+      'VLxU sign-extended',
+      'VLxU sign-extended, fault-only-first',
+    ]},
+    {bits: 5,  name: 'vd', attr: 'destination of load', type: 2},
+    {bits: 3,  name: 'width'},
+    {bits: 5,  name: 'rs1', attr: 'base address', type: 4},
+    {bits: 5,  name: 'lumop', attr: [0, 16, 0, 16]},
+    {bits: 1,  name: 'vm'},
+    {bits: 3,  name: 'mop', attr: [0, 0, 4, 4]},
+    {bits: 3,  name: 'nf'},
+]}
+{% endwavedrom %}
+```
+
+{% wavedrom %}
+{reg:[
+    {bits: 7,  name: 0x07, attr: [
+      'VLxU,VLE zero-extended',
+      'VLxU,VLE zero-extended, fault-only-first',
+      'VLxU sign-extended',
+      'VLxU sign-extended, fault-only-first',
+    ]},
+    {bits: 5,  name: 'vd', attr: 'destination of load', type: 2},
+    {bits: 3,  name: 'width'},
+    {bits: 5,  name: 'rs1', attr: 'base address', type: 4},
+    {bits: 5,  name: 'lumop', attr: [0, 16, 0, 16]},
+    {bits: 1,  name: 'vm'},
+    {bits: 3,  name: 'mop', attr: [0, 0, 4, 4]},
+    {bits: 3,  name: 'nf'},
+]}
+{% endwavedrom %}

--- a/source/docs/tag-plugins/wavedrom.md
+++ b/source/docs/tag-plugins/wavedrom.md
@@ -1,12 +1,12 @@
 ---
-title: Wavedrom
-description: NexT User Docs – NexT Supported Tags – Wavedrom
+title: WaveDrom
+description: NexT User Docs – NexT Supported Tags – WaveDrom
 ---
 
 ### Settings
 
 ```yml NexT config file
-# Wavedrom tag
+# WaveDrom tag
 wavedrom:
   enable: true
 ```

--- a/source/docs/tag-plugins/wavedrom.md
+++ b/source/docs/tag-plugins/wavedrom.md
@@ -11,6 +11,12 @@ wavedrom:
   enable: true
 ```
 
+```yml Hexo config file
+highlight:
+  exclude_languages:
+    - wavedrom
+```
+
 ### Usage
 
 ```jinja

--- a/source/docs/tag-plugins/wavedrom.md
+++ b/source/docs/tag-plugins/wavedrom.md
@@ -11,25 +11,12 @@ wavedrom:
   enable: true
 ```
 
-```yml Hexo config file
-highlight:
-  exclude_languages:
-    - wavedrom
-```
-
 ### Usage
 
 ```jinja
 {% wavedrom %}
 {% endwavedrom %}
 ```
-
-or
-
-~~~markdown
-```wavedrom
-```
-~~~
 
 ### Examples
 

--- a/source/docs/tag-plugins/wavedrom.md
+++ b/source/docs/tag-plugins/wavedrom.md
@@ -1,0 +1,46 @@
+---
+title: Wavedrom
+description: NexT User Docs – NexT Supported Tags – Wavedrom
+---
+
+### Settings
+
+```yml NexT config file
+# Wavedrom tag
+wavedrom:
+  enable: true
+```
+
+### Usage
+
+```jinja
+{% wavedrom %}
+{% endwavedrom %}
+```
+
+or
+
+~~~markdown
+```wavedrom
+```
+~~~
+
+### Examples
+
+```jinja
+{% wavedrom %}
+{ signal : [
+  { name: "clk",  wave: "p......" },
+  { name: "bus",  wave: "x.34.5x",   data: "head body tail" },
+  { name: "wire", wave: "0.1..0." },
+]}
+{% endwavedrom %}
+```
+
+{% wavedrom %}
+{ signal : [
+  { name: "clk",  wave: "p......" },
+  { name: "bus",  wave: "x.34.5x",   data: "head body tail" },
+  { name: "wire", wave: "0.1..0." },
+]}
+{% endwavedrom %}


### PR DESCRIPTION
This change adds documentation for next theme wavedrom tag plugin. It contains the syntax, configuration and example on how to use it.