### PR TITLE
Update front-matter.md

### DIFF
--- a/source/docs/advanced-settings/front-matter.md
+++ b/source/docs/advanced-settings/front-matter.md
@@ -31,6 +31,7 @@ Setting | Type | Description | Default
 --- | --- | --- | ---
 `author` | `string` | Author name for post copyright | `author` in Hexo config file
 `post_link` | `string` | The original link of the reposted article | None
+`copyright_reprint` | `bool` | It shows that the article is a reprint article and needs to enter `author` and `post_link` together. | `false`
 `link` | `string` | Clicking on the post title on the index or archive page will redirect to the set external link | None
 `description` | `string` | Docs [here](/docs/theme-settings/posts.html#Preamble-Text) | None
 `direction` | `string` | Available value: `rtl` | None


### PR DESCRIPTION
Add setting parameter:`copyright_reprint`

 在`Front-matter`中，应该还存在着一项独有于`NexT`的`Setting`：`copyright_reprint`
 
在官方GitHub仓库中的`layout/_partials/post/post-copyright.njk` [https://github.com/next-theme/hexo-theme-next/blob/master/layout/_partials/post/post-copyright.njk](https://github.com/next-theme/hexo-theme-next/blob/master/layout/_partials/post/post-copyright.njk) 代码的第25行，使用到了`page.copyright_reprint`这一个变量，实验后发现，该参数能够与文章开头设置的`author和post_link`进行联动，实现对转载文章的版权显示。因此提交PR申请，完善文档。
以下内容为翻译  The following content is a translation：
In the official GitHub repository, the `layout/_partials/post/post-copyright.njk` line 25 of the [https://github.com/next-theme/hexo-theme-next/blob/master/layout/_partials/post/post-copyright.njk](https://github.com/next-theme/hexo-theme-next/blob/master/layout/_partials/post/post-copyright.njk) code uses the variable `page.copyright_reprint`. After the experiment, it was found that the parameter can be linked to the `author` and `post_link` set at the beginning of the article to realize the copyright display of the reproduced article. Therefore, submit PR application and improve the document.